### PR TITLE
Fix setting hour of day in expiration check

### DIFF
--- a/src/main/java/com/javax0/license3j/licensor/ExtendedLicense.java
+++ b/src/main/java/com/javax0/license3j/licensor/ExtendedLicense.java
@@ -52,7 +52,7 @@ public class ExtendedLicense extends License {
     try {
       expiryDate = getFeature(EXPIRATION_DATE, Date.class);
       final GregorianCalendar today = new GregorianCalendar();
-      today.set(Calendar.HOUR, 0);
+      today.set(Calendar.HOUR_OF_DAY, 0);
       today.set(Calendar.MINUTE, 0);
       today.set(Calendar.SECOND, 0);
       today.set(Calendar.MILLISECOND, 0);


### PR DESCRIPTION
The `Calendar.HOUR` sets the hour of am/pm, so setting to 0 could set to 12pm instead of 12am, the 
correct field is [HOUR_OF_DAY](https://docs.oracle.com/javase/7/docs/api/java/util/Calendar.html#HOUR_OF_DAY)