### PR TITLE
Fix InterfaceSelector

### DIFF
--- a/src/main/java/com/javax0/license3j/licensor/hardware/InterfaceSelector.java
+++ b/src/main/java/com/javax0/license3j/licensor/hardware/InterfaceSelector.java
@@ -47,7 +47,7 @@ public class InterfaceSelector {
 
         return !matchesAny(name, deniedInterfaceNames)
                 &&
-                (!allowedInterfaceNames.isEmpty() ||
+                (allowedInterfaceNames.isEmpty() ||
                         matchesAny(name, allowedInterfaceNames));
     }
 


### PR DESCRIPTION
allowed check doesn't work because if the list is not empty, the interface is always validated