### PR TITLE
Enhance License3j with cloud provider instance id

### DIFF
--- a/src/main/java/javax0/license3j/HardwareBinder.java
+++ b/src/main/java/javax0/license3j/HardwareBinder.java
@@ -1,5 +1,6 @@
 package javax0.license3j;
 
+import javax0.license3j.hardware.CloudProvider;
 import javax0.license3j.hardware.Network;
 import javax0.license3j.hardware.UUIDCalculator;
 
@@ -31,6 +32,7 @@ public class HardwareBinder {
     private boolean useHostName = true;
     private boolean useNetwork = true;
     private boolean useArchitecture = true;
+    private CloudProvider cloudProvider;
 
     /**
      * A very simple main that prints out the machine UUID to the standard output.
@@ -84,6 +86,18 @@ public class HardwareBinder {
     }
 
     /**
+     * Add a cloud provider if you want to take into account the unique and immutable instance/machine id reported by teh provider.
+     * By default no cloud provider is taken into account.
+     *
+     * @param cloudProvider the desired cloud provider.
+     * @return the HardwareBinder object so method calls can be chained.
+     */
+    public HardwareBinder forCloudProvider(CloudProvider cloudProvider) {
+        this.cloudProvider = cloudProvider;
+        return this;
+    }
+
+    /**
      * Add a regular expression to the set of the regular expressions that are
      * checked against the display name of the network interface cards. If any
      * of the regular expressions are matched against the display name then the
@@ -103,6 +117,7 @@ public class HardwareBinder {
 
 
     public class Ignore {
+
         /**
          * When calculating the machine UUID the host name is also taken into
          * account by default. If you want the method to ignore the machine name
@@ -166,7 +181,7 @@ public class HardwareBinder {
      */
     public UUID getMachineId() throws NoSuchAlgorithmException,
         SocketException, UnknownHostException {
-        return calculator.getMachineId(useNetwork, useHostName, useArchitecture);
+        return calculator.getMachineId(cloudProvider, useNetwork, useHostName, useArchitecture);
     }
 
     /**
@@ -179,7 +194,7 @@ public class HardwareBinder {
      */
     public String getMachineIdString() throws NoSuchAlgorithmException,
         SocketException, UnknownHostException {
-        return calculator.getMachineIdString(useNetwork, useHostName, useArchitecture);
+        return calculator.getMachineIdString(cloudProvider, useNetwork, useHostName, useArchitecture);
     }
 
     /**
@@ -194,7 +209,7 @@ public class HardwareBinder {
     public boolean assertUUID(final UUID uuid)
         throws NoSuchAlgorithmException, SocketException,
         UnknownHostException {
-        return calculator.assertUUID(uuid, useNetwork, useHostName, useArchitecture);
+        return calculator.assertUUID(uuid, cloudProvider, useNetwork, useHostName, useArchitecture);
     }
 
     /**
@@ -204,7 +219,7 @@ public class HardwareBinder {
      * @return true if the argument passed is the uuid of the current machine.
      */
     public boolean assertUUID(final String uuid) {
-        return calculator.assertUUID(uuid, useNetwork, useHostName, useArchitecture);
+        return calculator.assertUUID(uuid, cloudProvider, useNetwork, useHostName, useArchitecture);
     }
 
 }

--- a/src/main/java/javax0/license3j/hardware/CloudProvider.java
+++ b/src/main/java/javax0/license3j/hardware/CloudProvider.java
@@ -20,7 +20,7 @@ public enum CloudProvider {
      */
     Azure {
         @Override
-        String getInstanceId() {
+        public String getInstanceId() {
             return instanceIdFor("http://169.254.169.254/metadata/instance/compute/vmId?api-version=2021-02-01&format=text", "Metadata", "true");
         }
     },
@@ -33,7 +33,7 @@ public enum CloudProvider {
      */
     AWS {
         @Override
-        String getInstanceId() {
+        public String getInstanceId() {
             return instanceIdFor("http://169.254.169.254/latest/meta-data/instance-id", "Metadata", "true");
         }
     },
@@ -47,13 +47,13 @@ public enum CloudProvider {
      */
     Google {
         @Override
-        String getInstanceId() {
+        public String getInstanceId() {
             return instanceIdFor("http://169.254.169.254/computeMetadata/v1/instance?alt=text", "Metadata-Flavor", "Google");
         }
     };
 
 
-    abstract String getInstanceId();
+    abstract public String getInstanceId();
 
 
     private static String instanceIdFor(String instanceIdUrl, String... headers) {

--- a/src/main/java/javax0/license3j/hardware/CloudProvider.java
+++ b/src/main/java/javax0/license3j/hardware/CloudProvider.java
@@ -1,0 +1,74 @@
+package javax0.license3j.hardware;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * Obtain the unique and immutable cloud instance/machine id, based on the dedicated, non-routable 169.254.169.254 ip address,
+ * as implemented by various cloud providers.
+ */
+public enum CloudProvider {
+
+    /**
+     * Obtain a Azure instance id.
+     * Refer to <a href="https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=windows">Azure documentation</a>
+     * Refer to <a href="https://gist.github.com/dreamorosi/50cbfd622b478c2433602c16b7321c5d">Examples</a>
+     */
+    Azure {
+        @Override
+        String getInstanceId() {
+            return instanceIdFor("http://169.254.169.254/metadata/instance/compute/vmId?api-version=2021-02-01&format=text", "Metadata", "true");
+        }
+    },
+
+    /**
+     * Obtain a AWS instance id.
+     * Refer to <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html">AWS documentation</a>
+     * Refer to <a href="https://gist.github.com/dreamorosi/50cbfd622b478c2433602c16b7321c5d">Examples</a>
+     * Refer to <a href="https://stackoverflow.com/questions/625644/how-to-get-the-instance-id-from-within-an-ec2-instance">Stack overflow</a>
+     */
+    AWS {
+        @Override
+        String getInstanceId() {
+            return instanceIdFor("http://169.254.169.254/latest/meta-data/instance-id", "Metadata", "true");
+        }
+    },
+
+    /**
+     * Obtain a Google cloud instance id.
+     * <p>
+     * Refer to <a href="https://cloud.google.com/compute/docs/metadata/overview">Google cloud documentation</a>
+     * Refer to <a href="https://cloud.yandex.com/en/docs/compute/operations/vm-info/get-info">Examples</a>
+     * Refer to <a href="https://stackoverflow.com/questions/31688646/get-the-name-or-id-of-the-current-google-compute-instance">Stack overflow</a>
+     */
+    Google {
+        @Override
+        String getInstanceId() {
+            return instanceIdFor("http://169.254.169.254/computeMetadata/v1/instance?alt=text", "Metadata-Flavor", "Google");
+        }
+    };
+
+
+    abstract String getInstanceId();
+
+
+    private static String instanceIdFor(String instanceIdUrl, String... headers) {
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request =
+                    HttpRequest
+                            .newBuilder(new URI(instanceIdUrl))
+                            .headers(headers)
+                            .GET()
+                            .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            return response.body();
+        } catch (InterruptedException | URISyntaxException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/javax0/license3j/hardware/HashCalculator.java
+++ b/src/main/java/javax0/license3j/hardware/HashCalculator.java
@@ -47,6 +47,11 @@ class HashCalculator {
         update(md5, architecture);
     }
 
+    void updateWithCloudInstanceId(final MessageDigest md5, final CloudProvider cloudProvider) {
+        final String instanceId = cloudProvider.getInstanceId();
+        update(md5, instanceId);
+    }
+
     private void update(final MessageDigest md5, final String input) {
         final byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
         md5.update(bytes, 0, bytes.length);

--- a/src/main/java/javax0/license3j/hardware/UUIDCalculator.java
+++ b/src/main/java/javax0/license3j/hardware/UUIDCalculator.java
@@ -13,9 +13,8 @@ import java.util.UUID;
  * of the UUID of a single machine can be managed with the parameters of the calculator, controlling what the
  * calculation takes into account. The less parameters you select the more stable the UUID will be. On the other hand
  * the less parameter you use the more machines may end-up having the same UUID.
- *
+ * <p>
  * Machne UUIDs may be used to restrict the usage of a software to certain machines.
- *
  */
 public class UUIDCalculator {
     private final HashCalculator calculator;
@@ -24,10 +23,13 @@ public class UUIDCalculator {
         this.calculator = new HashCalculator(selector);
     }
 
-    public UUID getMachineId(boolean useNetwork, boolean useHostName, boolean useArchitecture)
-        throws SocketException, UnknownHostException, NoSuchAlgorithmException {
+    public UUID getMachineId(CloudProvider cloudProvider, boolean useNetwork, boolean useHostName, boolean useArchitecture)
+            throws SocketException, UnknownHostException, NoSuchAlgorithmException {
         final var md5 = MessageDigest.getInstance("MD5");
         md5.reset();
+        if (cloudProvider != null) {
+            calculator.updateWithCloudInstanceId(md5, cloudProvider);
+        }
         if (useNetwork) {
             calculator.updateWithNetworkData(md5);
         }
@@ -41,21 +43,21 @@ public class UUIDCalculator {
         return UUID.nameUUIDFromBytes(digest);
     }
 
-    public String getMachineIdString(boolean useNetwork, boolean useHostName, boolean useArchitecture) throws
-        SocketException, UnknownHostException, NoSuchAlgorithmException {
-        final UUID uuid = getMachineId(useNetwork, useHostName, useArchitecture);
+    public String getMachineIdString(CloudProvider cloudProvider, boolean useNetwork, boolean useHostName, boolean useArchitecture) throws
+            SocketException, UnknownHostException, NoSuchAlgorithmException {
+        final UUID uuid = getMachineId(cloudProvider, useNetwork, useHostName, useArchitecture);
         return uuid.toString();
     }
 
-    public boolean assertUUID(final UUID uuid, boolean useNetwork, boolean useHostName, boolean useArchitecture)
-        throws SocketException, UnknownHostException, NoSuchAlgorithmException {
-        final UUID machineUUID = getMachineId(useNetwork, useHostName, useArchitecture);
+    public boolean assertUUID(final UUID uuid, CloudProvider cloudProvider, boolean useNetwork, boolean useHostName, boolean useArchitecture)
+            throws SocketException, UnknownHostException, NoSuchAlgorithmException {
+        final UUID machineUUID = getMachineId(cloudProvider, useNetwork, useHostName, useArchitecture);
         return machineUUID != null && machineUUID.equals(uuid);
     }
 
-    public boolean assertUUID(final String uuid, boolean useNetwork, boolean useHostName, boolean useArchitecture) {
+    public boolean assertUUID(final String uuid, CloudProvider cloudProvider, boolean useNetwork, boolean useHostName, boolean useArchitecture) {
         try {
-            return assertUUID(UUID.fromString(uuid), useNetwork, useHostName, useArchitecture);
+            return assertUUID(UUID.fromString(uuid), cloudProvider, useNetwork, useHostName, useArchitecture);
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module com.javax0.license3j {
+    requires java.net.http;
     exports javax0.license3j;
     exports javax0.license3j.crypto;
     exports javax0.license3j.io;


### PR DESCRIPTION
Add **unique and immutable instance id** to the hardware binding mix when computing the license uuid, which  cloud providers always assigns to a virtual machine/instance running the licensable app.  There are various ways to obtain the assigned instance id, but all providers implements a web service, which reports the instance id from within the instance, based on a well known, non-routable IP address: **169.254.169.254**, which this implementation exploits. 