### PR TITLE
Fix license verification failures on Android

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
                         --add-opens com.javax0.license3j/javax0.license3j.io=ALL-UNNAMED
                         --add-opens com.javax0.license3j/javax0.license3j.parsers=ALL-UNNAMED
                         --add-opens com.javax0.license3j/javax0.license3j.hardware=ALL-UNNAMED
+                        --add-opens java.base/java.lang=ALL-UNNAMED
                     </argLine>
                 </configuration>
                 <dependencies>

--- a/src/main/java/javax0/license3j/License.java
+++ b/src/main/java/javax0/license3j/License.java
@@ -139,7 +139,8 @@ public class License {
      */
     public boolean isOK(byte[] key) {
         try {
-            return isOK(LicenseKeyPair.Create.from(key, Modifier.PUBLIC).getPair().getPublic());
+            LicenseKeyPair lkp = LicenseKeyPair.Create.from(key, Modifier.PUBLIC);
+            return isOK(lkp.getPair().getPublic(), lkp.cipher());
         } catch (Exception e) {
             return false;
         }
@@ -154,11 +155,15 @@ public class License {
      * false}.
      */
     public boolean isOK(PublicKey key) {
+        return isOK(key, key.getAlgorithm());
+    }
+
+    private boolean isOK(PublicKey key, String algorithm) {
         try {
             final var digester = MessageDigest.getInstance(get(DIGEST_KEY).getString());
             final var ser = unsigned();
             final var digestValue = digester.digest(ser);
-            final var cipher = Cipher.getInstance(key.getAlgorithm());
+            final var cipher = Cipher.getInstance(algorithm);
             cipher.init(Cipher.DECRYPT_MODE, key);
             final var sigDigest = cipher.doFinal(getSignature());
             return Arrays.equals(digestValue, sigDigest);


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/verhas/License3j/issues/61#issuecomment-583440230 and https://github.com/verhas/License3j/issues/61#issuecomment-942855082 without hackily hardcoding the key algorithm string, provided the serialised public key file has been generated with the full algorithm specification (e.g. `RSA/ECB/PKCS1Padding` instead of merely `RSA`) as well.